### PR TITLE
Changing the underlying protocol to TLS/HTTPS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,21 +4,12 @@ var Fred, http, root;
  * @class Fred
  * @constructor
  * @param {String} apiKey FRED API key. To obtain, register at https://research.stlouisfed.org/useraccount/register/
- * @param {Boolean} useHttp (Optional, useHttp=false) Set true to use insecure but slightly faster HTTP, don't touch if HTTPS is ok.
  */
-Fred = function(apiKey, useHttp) {
+Fred = function(apiKey) {
     'use strict';
     this.apiKey = apiKey;
-    this.useHttp = false;
-    if (useHttp !== undefined) this.useHttp = useHttp;
-    if (this.useHttp) {
-        http = require('http');
-        root = 'http://api.stlouisfed.org/fred/';
-    }
-    else {
-        http = require('https');
-        root = 'https://api.stlouisfed.org/fred/';
-    }
+    http = require('https');
+    root = 'https://api.stlouisfed.org/fred/';
 };
 
 Fred.prototype.get = function(url, params, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,11 +13,11 @@ Fred = function(apiKey, useHttp) {
     if (useHttp !== undefined) this.useHttp = useHttp;
     if (this.useHttp) {
         http = require('http');
-        root = 'http://api.stlouisfed.org/fred';
+        root = 'http://api.stlouisfed.org/fred/';
     }
     else {
         http = require('https');
-        root = 'https://api.stlouisfed.org/fred';
+        root = 'https://api.stlouisfed.org/fred/';
     }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,24 @@
 var Fred, http, root;
 
-http = require('https');
-root = 'https://api.stlouisfed.org/fred/';
-
-Fred = function(apiKey) {
+/**
+ * @class Fred
+ * @constructor
+ * @param {String} apiKey FRED API key. To obtain, register at https://research.stlouisfed.org/useraccount/register/
+ * @param {Boolean} useHttp (Optional, useHttp=false) Set true to use insecure but slightly faster HTTP, don't touch if HTTPS is ok.
+ */
+Fred = function(apiKey, useHttp) {
     'use strict';
     this.apiKey = apiKey;
+    this.useHttp = false;
+    if (useHttp !== undefined) this.useHttp = useHttp;
+    if (this.useHttp) {
+        http = require('http');
+        root = 'http://api.stlouisfed.org/fred';
+    }
+    else {
+        http = require('https');
+        root = 'https://api.stlouisfed.org/fred';
+    }
 };
 
 Fred.prototype.get = function(url, params, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var Fred, http, root;
 
-http = require('http');
-root = 'http://api.stlouisfed.org/fred/';
+http = require('https');
+root = 'https://api.stlouisfed.org/fred/';
 
 Fred = function(apiKey) {
     'use strict';


### PR DESCRIPTION
Rationale: anybody can see and modify the data. While it is not as urgent for APIs like FRED, changing over to TLS prevents MITM attacks exploiting vulnerabilities in the API parser.
